### PR TITLE
Forget to remove Unique Stros M'Kai Rum?

### DIFF
--- a/content/skyrim-se/mod-installation/food-ingredients.md
+++ b/content/skyrim-se/mod-installation/food-ingredients.md
@@ -63,12 +63,6 @@ description: >
 
 * **Main Files:** Medieval Spirits
 
-##### [Unique Stros M'Kai Rum](https://www.nexusmods.com/skyrimspecialedition/mods/43830?tab=files)
-
-#### Download Instructions
-
-- **Main Files:** Stros M'Kai Rum Replacer 1K
-
 ##### [Remiros' Dragonborn Alcohol HD](https://www.nexusmods.com/skyrimspecialedition/mods/41972?tab=files)
 
 #### Download Instructions


### PR DESCRIPTION
The mod is flagged as removed in the last changelog note but it's still in the list.