### PR TITLE
Remove localized link

### DIFF
--- a/content/tpf/initial-setup/the-creation-kit.md
+++ b/content/tpf/initial-setup/the-creation-kit.md
@@ -10,7 +10,7 @@ description: >
 
 With the release of Skyrim SE, Bethesda also published a new version of their official tool kit, the Creation Kit (or CK for short), updated for the new 64bit engine. Unfortunately the CK 2.0 can no longer be downloaded directly from Steam but requires the Bethesda Launcher and a Beth.net account.
 
-- Go to [Bethesda.net](https://bethesda.net/de/dashboard), the official website.
+- Go to [Bethesda.net](https://bethesda.net), the official website.
 - Scroll all the way down to the footer (bottom of the page).
 - Click the **Download** button in the **Bethesda Launcher** section.
 - Double-click the downloaded executable.


### PR DESCRIPTION
Originally pointed to the German version of the site, so instead now it points to the version which will redirect based on your locale 👍