### PR TITLE
Removed No More Follower Hunting Bows - will be integrated into the CRP.

### DIFF
--- a/content/tpf/mod-installation/tweaks.md
+++ b/content/tpf/mod-installation/tweaks.md
@@ -92,12 +92,6 @@ description: >
 
 - **Main Files:** Followers Don't Draw Weapons v1.0.1
 
-##### [No More Follower Hunting Bows](https://www.nexusmods.com/skyrimspecialedition/mods/11713?tab=files)
-
-#### Download Instructions
-
-- **Main Files:** NoMoreFollowerHuntingBows
-
 ##### [Random Encounter Tweaks](https://www.nexusmods.com/skyrimspecialedition/mods/16804?tab=files)
 
 #### Download Instructions


### PR DESCRIPTION
No More Follower Hunting Bows doesn't forward USSEP edits, but it's a 1-record mod so patching it also includes the entire mod within TPF itself - as such there's no reason to download the file.